### PR TITLE
Add in example SQL for orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment Configuration
+.env


### PR DESCRIPTION
Prepares for adding in custom rego/inputs/sql for any other example data filtering scenarios.

This probably isn't the cleanest or most idiomatic way to do this in typescript, but it gets the job done for right now.